### PR TITLE
Invert Quest State (For Kiosk Switch)

### DIFF
--- a/libraries/libexosphere/source/fuse/fuse_api.cpp
+++ b/libraries/libexosphere/source/fuse/fuse_api.cpp
@@ -358,7 +358,8 @@ namespace ams::fuse {
     }
 
     RetailInteractiveDisplayState GetRetailInteractiveDisplayState() {
-        return static_cast<RetailInteractiveDisplayState>(util::BitPack32{GetCommonOdmWord(4)}.Get<OdmWord4::RetailInteractiveDisplayState>());
+        /* I do this so I can be incredibly lazy with certain things, please don't kill me :( */
+        return static_cast<RetailInteractiveDisplayState>(!util::BitPack32{GetCommonOdmWord(4)}.Get<OdmWord4::RetailInteractiveDisplayState>());
     }
 
     pmic::Regulator GetRegulator() {


### PR DESCRIPTION
This inverts the Quest state so that this build may be used on Kiosk Switch units.